### PR TITLE
Add session resumption and progress tracking to agent workflow

### DIFF
--- a/docs_agents/PROMPT.md
+++ b/docs_agents/PROMPT.md
@@ -68,9 +68,18 @@ At the start of every agent session, execute in this exact order:
 3. Read `docs_agents/review_cache.json` — load session state and previous findings.
 4. Check `docs_agents/bugs.md` and `docs_agents/refactoring_backlog.md`.
 5. Run **Step 0 — Live API Verification** (see below).
-6. Select the next pending session from the session type registry.
-7. Execute the session, respecting scope limits.
-8. Update `review_cache.json`, `bugs.md`, `refactoring_backlog.md` and write a report.
+6. **Check for `in_progress` sessions first.**
+   - If any session has `"status": "in_progress"`, resume it from where it stopped
+     (see `progress_notes` in `review_cache.json`).
+   - Only if no `in_progress` session exists, select the next `pending` session.
+   - **Never skip an `in_progress` session** — mark it `done` only after full completion.
+7. At the start of the selected session, immediately set its status to `in_progress`
+   and write `progress_notes` describing which step you are about to execute.
+   Update `review_cache.json` before doing any further work.
+8. Execute the session step by step. After completing each major step, update
+   `progress_notes` in `review_cache.json` so that a future agent can resume correctly.
+9. Update `review_cache.json` (set `status` to `done`), `bugs.md`,
+   `refactoring_backlog.md` and write a report.
 
 ---
 
@@ -313,20 +322,24 @@ Create and maintain: `docs_agents/review_cache.json`
 
 ```json
 {
-  "schema_version": "2",
+  "schema_version": "3",
   "last_updated": "<iso8601>",
   "sessions": {
     "S01": {
-      "status": "pending|done|skipped",
+      "status": "pending|in_progress|done|skipped",
+      "started_at": null,
       "completed_at": null,
       "report_path": null,
-      "step0_results": null
+      "step0_results": null,
+      "progress_notes": null
     },
     "S02": {
-      "status": "pending|done|skipped",
+      "status": "pending|in_progress|done|skipped",
+      "started_at": null,
       "completed_at": null,
       "report_path": null,
-      "step0_results": null
+      "step0_results": null,
+      "progress_notes": null
     }
   },
   "known_issues": {
@@ -422,3 +435,11 @@ Agents must not self-modify `PROMPT.md`.
 6. All PRs target `main`. Branch naming: `agents/<agent>/<topic>`.
 7. Never push directly to `main`.
 8. Changes to `docs_agents/` require human review before merge.
+9. **Never skip an `in_progress` session.** If `review_cache.json` contains a session
+   with `"status": "in_progress"`, that session must be resumed and completed before
+   starting any other session. A session is only `done` when its report has been written
+   and `review_cache.json` has been updated accordingly.
+10. **Set `in_progress` before starting work.** Always update `review_cache.json`
+    to `"status": "in_progress"` (with `started_at` and initial `progress_notes`)
+    before executing any steps of a session. This ensures a future agent can detect
+    and resume a partially completed session even if the current run is interrupted.


### PR DESCRIPTION
## Summary
This PR enhances the docs_agents workflow to support resuming interrupted sessions. It introduces session state tracking with `in_progress` status, progress notes, and timestamps to enable agents to detect and continue partially completed work.

## Key Changes

- **Session state management**: Added `in_progress` status to the session lifecycle (`pending` → `in_progress` → `done`), allowing agents to resume interrupted work
- **Progress tracking**: Introduced `progress_notes` field in `review_cache.json` to record which step a session stopped at, enabling accurate resumption
- **Startup logic**: Modified agent initialization to check for `in_progress` sessions first and resume them before starting new `pending` sessions
- **Checkpoint updates**: Agents now update `progress_notes` after each major step, creating checkpoints for safe resumption
- **Schema versioning**: Bumped `review_cache.json` schema from v2 to v3 with new fields: `started_at`, `progress_notes`, and updated `status` enum
- **Enforcement rules**: Added explicit guidelines that `in_progress` sessions must never be skipped and must be marked `done` only after full completion

## Implementation Details

- Sessions now track `started_at` timestamp in addition to `completed_at`
- The `progress_notes` field captures the exact step/state where work stopped, allowing deterministic resumption
- Agents must set `in_progress` status and write initial `progress_notes` before executing any session steps
- The workflow prioritizes resuming incomplete work over starting new sessions, preventing session abandonment

https://claude.ai/code/session_01J2RL9Y4nQR3kRX9iCXYzyk